### PR TITLE
Modify registry checks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,10 +21,10 @@ module.exports = {
     "no-use-before-define": "warn",
     "no-undef": "warn",
     "object-curly-newline": 0,
-    "quotes": [2, "double"],
-    "operator-linebreak" : 0,
-    "no-param-reassign" : 0,
-    "no-unused-expressions" :0,
-    "prettier/prettier": ["error"]
+    quotes: [2, "double"],
+    "operator-linebreak": 0,
+    "no-param-reassign": 0,
+    "no-unused-expressions": 0,
+    "prettier/prettier": ["error"],
   },
 };

--- a/src/contracts/IdleRouter.sol
+++ b/src/contracts/IdleRouter.sol
@@ -34,7 +34,7 @@ contract IdleRouter is OwnableUpgradeable {
 
     /**
      * @notice initialize contract and set the idleRegistry address
-     * @param _idleRegistry address of the token-to-CDO registry 
+     * @param _idleRegistry address of the token-to-CDO registry
      */
     function initialize(address _idleRegistry) external initializer {
         OwnableUpgradeable.__Ownable_init();
@@ -43,7 +43,7 @@ contract IdleRouter is OwnableUpgradeable {
 
     /**
      * @notice change the idleRegistry address
-     * @param _idleRegistry new address of the token-to-CDO registry 
+     * @param _idleRegistry new address of the token-to-CDO registry
      */
     function setIdleRegistry(address _idleRegistry) public onlyOwner {
         require(
@@ -55,7 +55,7 @@ contract IdleRouter is OwnableUpgradeable {
     }
 
     /**
-     * @notice deposit tokens into the AA CDO Tranche. Note: approvals must be made before 
+     * @notice deposit tokens into the AA CDO Tranche. Note: approvals must be made before
      * this call to allow the router to move your assets on your behalf
      * @param _cdo address of the CDO contract
      * @param _amount of the underlying token to deposit
@@ -100,23 +100,24 @@ contract IdleRouter is OwnableUpgradeable {
      * @param _cdo address of the CDO contract
      * @param _amount of the underlying token to deposit
      * @param isAATranche set to true to deposit into an AA Tranche,
-     * set to false to deposit into a BB Tranche 
+     * set to false to deposit into a BB Tranche
      */
     function _deposit(
         address _cdo,
         uint256 _amount,
         bool isAATranche
     ) internal {
-        address tokenAddress = IIdleRegistry(idleRegistry).idleCdoToToken(
-            _cdo
-        );
+        address tokenAddress = IIdleRegistry(idleRegistry).idleCdoToToken(_cdo);
 
         require(tokenAddress != address(0), "IdleRouter: INVALID_CDO");
         require(_amount != 0, "IdleRouter: INVALID_AMOUNT");
 
         IIdleCDO idleCdo = IIdleCDO(_cdo);
 
-        require(idleCdo.token() == tokenAddress, "IdleRouter: UNDERLYING_TOKEN_MISMATCH");
+        require(
+            idleCdo.token() == tokenAddress,
+            "IdleRouter: UNDERLYING_TOKEN_MISMATCH"
+        );
 
         IERC20Upgradeable trancheToken = IERC20Upgradeable(
             isAATranche ? idleCdo.AATranche() : idleCdo.BBTranche()
@@ -133,9 +134,7 @@ contract IdleRouter is OwnableUpgradeable {
 
         underlyingToken.safeTransferFrom(msg.sender, address(this), _amount);
 
-        if (
-            underlyingToken.allowance(address(this), _cdo) < _amount
-        ) {
+        if (underlyingToken.allowance(address(this), _cdo) < _amount) {
             // Avoid issues with some tokens requiring 0
             underlyingToken.safeApprove(_cdo, 0);
             underlyingToken.safeApprove(_cdo, type(uint256).max);
@@ -167,7 +166,7 @@ contract IdleRouter is OwnableUpgradeable {
      * @param _trancheTokenAddress the CDO Tranche token address
      * @param _amount of the Tranche token token to burn
      * @param isAATranche set to true to withdraw from an AA Tranche,
-     * set to false to withdraw from a BB Tranche 
+     * set to false to withdraw from a BB Tranche
      */
     function _withdraw(
         address _trancheTokenAddress,
@@ -175,7 +174,10 @@ contract IdleRouter is OwnableUpgradeable {
         bool isAATranche
     ) internal {
         address idleCDOAddress = IIdleCDOTranche(_trancheTokenAddress).minter();
-        require(IIdleRegistry(idleRegistry).isValidCdo(idleCDOAddress), "IdleRouter: INVALID_TOKEN");
+        require(
+            IIdleRegistry(idleRegistry).isValidCdo(idleCDOAddress),
+            "IdleRouter: INVALID_TOKEN"
+        );
 
         IIdleCDO idleCdo = IIdleCDO(idleCDOAddress);
         IERC20Upgradeable trancheToken = IERC20Upgradeable(

--- a/src/contracts/IdleRouter.sol
+++ b/src/contracts/IdleRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.11;
+pragma solidity ^0.8.11;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
@@ -57,26 +57,27 @@ contract IdleRouter is OwnableUpgradeable {
     /**
      * @notice deposit tokens into the AA CDO Tranche. Note: approvals must be made before 
      * this call to allow the router to move your assets on your behalf
-     * @param _token the underlying token for the CDO
+     * @param _cdo address of the CDO contract
      * @param _amount of the underlying token to deposit
      */
-    function depositAA(address _token, uint256 _amount) external {
-        _deposit(_token, _amount, true);
+    function depositAA(address _cdo, uint256 _amount) external {
+        _deposit(_cdo, _amount, true);
     }
 
     /**
      * @notice deposit tokens into the BB CDO Tranche. Note: approvals must be made before
      * this call to allow the router to move your assets on your behalf
-     * @param _token the underlying token for the CDO
+     * @param _cdo address of the CDO contract
      * @param _amount of the underlying token to deposit
      */
-    function depositBB(address _token, uint256 _amount) external {
-        _deposit(_token, _amount, false);
+    function depositBB(address _cdo, uint256 _amount) external {
+        _deposit(_cdo, _amount, false);
     }
 
     /**
      * @notice burn AA Tranche tokens and get the principal + interest back. Note: approvals
      * must be made before this call to allow the router to move your assets on your behalf
+     * @param _trancheTokenAA the CDO AA Tranche token address
      * @param _amount of the AA Tranche token to burn
      */
     function withdrawAA(address _trancheTokenAA, uint256 _amount) external {
@@ -86,6 +87,7 @@ contract IdleRouter is OwnableUpgradeable {
     /**
      * @notice burn BB Tranche tokens and get the principal + interest back. Note: approvals
      * must be made before this call to allow the router to move your assets on your behalf
+     * @param _trancheTokenBB the CDO BB Tranche token address
      * @param _amount of the BB Tranche token to burn
      */
     function withdrawBB(address _trancheTokenBB, uint256 _amount) external {
@@ -95,28 +97,32 @@ contract IdleRouter is OwnableUpgradeable {
     /**
      * @notice base function for depositing tokens into the CDO Tranches. Note: approvals
      * must be made before this call to allow the router to move your assets on your behalf
-     * @param _token the underlying token for the CDO
+     * @param _cdo address of the CDO contract
      * @param _amount of the underlying token to deposit
      * @param isAATranche set to true to deposit into an AA Tranche,
      * set to false to deposit into a BB Tranche 
      */
     function _deposit(
-        address _token,
+        address _cdo,
         uint256 _amount,
         bool isAATranche
     ) internal {
-        address idleCDOAddress = IIdleRegistry(idleRegistry).tokenToIdleCDO(
-            _token
+        address tokenAddress = IIdleRegistry(idleRegistry).idleCdoToToken(
+            _cdo
         );
-        require(idleCDOAddress != address(0), "IdleRouter: INVALID_TOKEN");
+
+        require(IIdleRegistry(idleRegistry).isValidCdo(_cdo), "IdleRegistry: INVALID_CDO");
         require(_amount != 0, "IdleRouter: INVALID_AMOUNT");
 
-        IIdleCDO idleCdo = IIdleCDO(idleCDOAddress);
+        IIdleCDO idleCdo = IIdleCDO(_cdo);
+
+        require(idleCdo.token() == tokenAddress, "IdleRouter: UNDERLYING_TOKEN_MISMATCH");
+
         IERC20Upgradeable trancheToken = IERC20Upgradeable(
             isAATranche ? idleCdo.AATranche() : idleCdo.BBTranche()
         );
 
-        IERC20Upgradeable underlyingToken = IERC20Upgradeable(_token);
+        IERC20Upgradeable underlyingToken = IERC20Upgradeable(tokenAddress);
 
         uint256 trancheTokenBalanceBefore = trancheToken.balanceOf(
             address(this)
@@ -128,14 +134,11 @@ contract IdleRouter is OwnableUpgradeable {
         underlyingToken.safeTransferFrom(msg.sender, address(this), _amount);
 
         if (
-            underlyingToken.allowance(address(this), idleCDOAddress) < _amount
+            underlyingToken.allowance(address(this), _cdo) < _amount
         ) {
             // Avoid issues with some tokens requiring 0
-            underlyingToken.safeApprove(address(idleCDOAddress), 0);
-            underlyingToken.safeApprove(
-                address(idleCDOAddress),
-                type(uint256).max
-            );
+            underlyingToken.safeApprove(_cdo, 0);
+            underlyingToken.safeApprove(_cdo, type(uint256).max);
         }
 
         uint256 qtyMinted = isAATranche
@@ -152,7 +155,7 @@ contract IdleRouter is OwnableUpgradeable {
 
         emit TokensDeposited(
             msg.sender,
-            _token,
+            address(underlyingToken),
             address(trancheToken),
             _amount
         );
@@ -161,7 +164,7 @@ contract IdleRouter is OwnableUpgradeable {
     /**
      * @notice base function for withdrawing the underlying with interest. Note: approvals
      * must be made before this call to allow the router to move your assets on your behalf
-     * @param _trancheTokenAddress the CDO Tranche token
+     * @param _trancheTokenAddress the CDO Tranche token address
      * @param _amount of the Tranche token token to burn
      * @param isAATranche set to true to withdraw from an AA Tranche,
      * set to false to withdraw from a BB Tranche 
@@ -172,7 +175,7 @@ contract IdleRouter is OwnableUpgradeable {
         bool isAATranche
     ) internal {
         address idleCDOAddress = IIdleCDOTranche(_trancheTokenAddress).minter();
-        require(idleCDOAddress != address(0), "IdleRouter: INVALID_TOKEN");
+        require(IIdleRegistry(idleRegistry).isValidCdo(idleCDOAddress), "IdleRouter: INVALID_TOKEN");
 
         IIdleCDO idleCdo = IIdleCDO(idleCDOAddress);
         IERC20Upgradeable trancheToken = IERC20Upgradeable(
@@ -194,7 +197,7 @@ contract IdleRouter is OwnableUpgradeable {
 
         trancheToken.transferFrom(msg.sender, address(this), _amount);
 
-        // NOTE: no approval required for withdrawal!
+        // Note: no approval required for withdrawal!
         uint256 amountToReturn = isAATranche
             ? idleCdo.withdrawAA(_amount)
             : idleCdo.withdrawBB(_amount);

--- a/src/contracts/IdleRouter.sol
+++ b/src/contracts/IdleRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity ^0.8.11;
+pragma solidity 0.8.11;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
@@ -111,7 +111,7 @@ contract IdleRouter is OwnableUpgradeable {
             _cdo
         );
 
-        require(IIdleRegistry(idleRegistry).isValidCdo(_cdo), "IdleRegistry: INVALID_CDO");
+        require(tokenAddress != address(0), "IdleRouter: INVALID_CDO");
         require(_amount != 0, "IdleRouter: INVALID_AMOUNT");
 
         IIdleCDO idleCdo = IIdleCDO(_cdo);
@@ -156,7 +156,7 @@ contract IdleRouter is OwnableUpgradeable {
         emit TokensDeposited(
             msg.sender,
             address(underlyingToken),
-            address(trancheToken),
+            tokenAddress,
             _amount
         );
     }

--- a/src/interfaces/IIdleRegistry.sol
+++ b/src/interfaces/IIdleRegistry.sol
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.11;
+pragma solidity ^0.8.11;
 
 interface IIdleRegistry {
-    function tokenToIdleCDO(address underlyingToken)
+    function idleCdoToToken(address idleCdo)
         external
         view
         returns (address);
+
+    function isValidCdo(address idleCdo)
+        external
+        view
+        returns (bool);
 }

--- a/src/interfaces/IIdleRegistry.sol
+++ b/src/interfaces/IIdleRegistry.sol
@@ -2,13 +2,7 @@
 pragma solidity ^0.8.11;
 
 interface IIdleRegistry {
-    function idleCdoToToken(address idleCdo)
-        external
-        view
-        returns (address);
+    function idleCdoToToken(address idleCdo) external view returns (address);
 
-    function isValidCdo(address idleCdo)
-        external
-        view
-        returns (bool);
+    function isValidCdo(address idleCdo) external view returns (bool);
 }

--- a/src/mocks/IdleRegistry.sol
+++ b/src/mocks/IdleRegistry.sol
@@ -15,11 +15,7 @@ contract IdleRegistry is Ownable {
         idleCdoToToken[idleCdo] = underlyingToken;
     }
 
-    function isValidCdo(address _cdo)
-        external
-        view
-        returns(bool)
-    {
+    function isValidCdo(address _cdo) external view returns (bool) {
         return idleCdoToToken[_cdo] != address(0);
     }
 }

--- a/src/mocks/IdleRegistry.sol
+++ b/src/mocks/IdleRegistry.sol
@@ -1,17 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.11;
+pragma solidity ^0.8.11;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract IdleRegistry is Ownable {
-    mapping(address => address) public tokenToIdleCDO;
+    mapping(address => address) public idleCdoToToken;
 
     constructor() {}
 
-    function addIdleCDO(address underlyingToken, address idleCDO)
+    function setIdleCdo(address idleCdo, address underlyingToken)
         external
         onlyOwner
     {
-        tokenToIdleCDO[underlyingToken] = idleCDO;
+        idleCdoToToken[idleCdo] = underlyingToken;
+    }
+
+    function isValidCdo(address _cdo)
+        external
+        view
+        returns(bool)
+    {
+        return idleCdoToToken[_cdo] != address(0);
     }
 }

--- a/src/mocks/IdleRouterV2.sol
+++ b/src/mocks/IdleRouterV2.sol
@@ -7,6 +7,6 @@ contract IdleRouterV2 is IdleRouter {
     bool public isUpgraded;
 
     function setUpgraded(bool _isUpgraded) external {
-      isUpgraded = _isUpgraded;
+        isUpgraded = _isUpgraded;
     }
 }

--- a/src/mocks/IdleRouterV2.sol
+++ b/src/mocks/IdleRouterV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.11;
+pragma solidity ^0.8.11;
 
 import "../contracts/IdleRouter.sol";
 

--- a/test/contracts/idleRouterTests.js
+++ b/test/contracts/idleRouterTests.js
@@ -103,7 +103,7 @@ describe("IdleRouter", () => {
   });
 
   describe("depositAA", () => {
-    it("succeeds for a token in the registry", async () => {
+    it("succeeds for a CDO in the registry", async () => {
       const staker1 = accounts[1];
       const amountToTransfer = ethers.utils.parseUnits("50", 18);
       const initialDaiBalanceOfStaker1 = await daiToken.balanceOf(
@@ -141,7 +141,7 @@ describe("IdleRouter", () => {
         idleRouter
           .connect(staker1)
           .depositAA(daiAAToken.address, amountToTransfer)
-      ).to.be.revertedWith("IdleRegistry: INVALID_CDO");
+      ).to.be.revertedWith("IdleRouter: INVALID_CDO");
     });
 
     it("reverts with an _amount of zero", async () => {
@@ -154,7 +154,7 @@ describe("IdleRouter", () => {
     });
 
     it("reverts for an incorrect underlying token in the registy", async () => {
-      // set an incorrect CDO / underlying token pair
+      // set an incorrect CDO -> underlying token pair
       await idleRegistry.setIdleCdo(DAI_CDO_ADDRESS, BUSD_ADDRESS);
 
       const staker1 = accounts[1];
@@ -213,7 +213,7 @@ describe("IdleRouter", () => {
   });
 
   describe("depositBB", () => {
-    it("succeeds for a token in the registry", async () => {
+    it("succeeds for a CDO in the registry", async () => {
       const staker1 = accounts[1];
       const amountToTransfer = ethers.utils.parseUnits("50", 18);
       const initialDaiBalanceOfStaker1 = await daiToken.balanceOf(
@@ -251,12 +251,12 @@ describe("IdleRouter", () => {
         idleRouter
           .connect(staker1)
           .depositBB(daiAAToken.address, amountToTransfer)
-      ).to.be.revertedWith("IdleRegistry: INVALID_CDO");
+      ).to.be.revertedWith("IdleRouter: INVALID_CDO");
     });
   });
 
   describe("withdrawAA", () => {
-    it("succeeds for a token in the registry", async () => {
+    it("succeeds for a CDO in the registry", async () => {
       const staker1 = accounts[1];
       const amountToTransfer = ethers.utils.parseUnits("50", 18);
       const initialDaiBalanceOfStaker1 = await daiToken.balanceOf(
@@ -375,7 +375,7 @@ describe("IdleRouter", () => {
   });
 
   describe("withdrawBB", () => {
-    it("succeeds for a token in the registry", async () => {
+    it("succeeds for a CDO in the registry", async () => {
       const staker1 = accounts[1];
       const amountToTransfer = ethers.utils.parseUnits("50", 18);
       const initialDaiBalanceOfStaker1 = await daiToken.balanceOf(
@@ -444,7 +444,7 @@ describe("IdleRouter", () => {
       expect(await idleRouterV2.isUpgraded()).to.equal(true);
     });
 
-    it("deposit succeeds for a token in the registry after an upgrade", async () => {
+    it("deposit succeeds for a CDO in the registry after an upgrade", async () => {
       const IdleRouterV2 = await ethers.getContractFactory("IdleRouterV2");
       const idleRouterV2 = await upgrades.upgradeProxy(
         idleRouter.address,
@@ -498,7 +498,7 @@ describe("IdleRouter", () => {
         idleRouterV2
           .connect(staker1)
           .depositAA(daiAAToken.address, amountToTransfer)
-      ).to.be.revertedWith("IdleRegistry: INVALID_CDO");
+      ).to.be.revertedWith("IdleRouter: INVALID_CDO");
     });
   });
 });


### PR DESCRIPTION
- [x] Modify all deposit functions to the following function signature `depositAA(address _cdo, uint256 _amount)`
- [x] The passed in _cdo address needs to be confirmed as a valid _cdo address against the registry
- [x] In withdraw, check that the minter() address is a valid cdo address
- [x] Modify the registry to expose the needed functionality `isValidCdo(_cdo)`
- [x] Update all tests, and include tests for all reverts and failure states

A few notes. IdleRegistry mapping is now CDO -> underlyingToken. This avoids creating a complex mapping with multiple CDOs for one underlying and makes checking valid CDOs easier. It works because all CDOs only have one underlying token.

A new check has also been implemented that confirms the CDO -> underlyingToken pairing is correct by getting the underlying token from the CDO itself and comparing it to the existing one (see [here](https://github.com/shapeshift/idle-router/compare/develop...Bielwenass:develop#diff-35147b35cda12a5ce6ed72c8653c80b0273cc632bd6222833ac82f7ae0548140R119)), a test for that has also been put in place.

Please let me know if any changes are needed.
